### PR TITLE
added capture name

### DIFF
--- a/src/RegExpBuilder.php
+++ b/src/RegExpBuilder.php
@@ -108,7 +108,9 @@ class RegExpBuilder
     private function flushState()
     {
         if ($this->_of != "" || $this->_ofAny || $this->_ofGroup > 0 || $this->_from != "" || $this->_notFrom != "" || $this->_like != "") {
-            $captureLiteral   = $this->_capture ? "" : "?:";
+            $captureLiteral   = $this->_capture
+                ? $this->_captureName ? "?P<".$this->_captureName.">" : "?:"
+                : "?:";
             $quantityLiteral  = $this->getQuantityLiteral();
             $characterLiteral = $this->getCharacterLiteral();
             $reluctantLiteral = $this->_reluctant ? "?" : "";
@@ -430,9 +432,10 @@ class RegExpBuilder
         return $this;
     }
 
-    public function asGroup()
+    public function asGroup($name = null)
     {
         $this->_capture = true;
+        $this->_captureName = $name;
         $this->_groupsUsed++;
 
         return $this;
@@ -665,4 +668,3 @@ class RegExpBuilder
     }
 
 }
-

--- a/src/RegExpBuilder.php
+++ b/src/RegExpBuilder.php
@@ -81,6 +81,10 @@ class RegExpBuilder
      */
     protected $_capture;
 
+    /**
+     * @var string
+     */
+    protected $_captureName;
 
     public function __construct()
     {
@@ -109,7 +113,7 @@ class RegExpBuilder
     {
         if ($this->_of != "" || $this->_ofAny || $this->_ofGroup > 0 || $this->_from != "" || $this->_notFrom != "" || $this->_like != "") {
             $captureLiteral   = $this->_capture
-                ? $this->_captureName ? "?P<".$this->_captureName.">" : "?:"
+                ? $this->_captureName ? "?P<".$this->_captureName.">" : ""
                 : "?:";
             $quantityLiteral  = $this->getQuantityLiteral();
             $characterLiteral = $this->getCharacterLiteral();


### PR DESCRIPTION
note that,  if named, the group will be included twice in the preg_match array:

``` php
   [0]: string (49) "n° 1802"
 · [myname]: string (4) "1802"
 · [1]: string (4) "1802"
```
