### PR TITLE
Remove deprecation warnings for flags parameter

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
          verbose="true"
->
-    <testsuites>
-        <testsuite>
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+         convertDeprecationsToExceptions="true"
+         >
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="error_reporting" value="E_ALL"/>
+  </php>
 </phpunit>

--- a/src/RegExp.php
+++ b/src/RegExp.php
@@ -16,7 +16,7 @@ class RegExp
     protected $_flags;
 
     /**
-     * @var String
+     * @var int
      */
     protected $_pregMatchFlags;
 
@@ -25,7 +25,7 @@ class RegExp
      */
     protected $_method = "preg_match";
 
-    public function __construct($expr, $flags, $pregMatchFlags = null)
+    public function __construct($expr, $flags, $pregMatchFlags = 0)
     {
         $this->_expr  = $expr;
         $this->_flags = $flags;
@@ -75,7 +75,7 @@ class RegExp
                 sprintf("/%s/%s", $this->_expr, $this->_flags),
                 $string,
                 &$matches,
-                $this->_pregMatchFlags ?: null,
+                $this->_pregMatchFlags ?: 0,
             ]
         );
     }
@@ -99,7 +99,7 @@ class RegExp
                 sprintf("/%s/%s", $this->_expr, $this->_flags),
                 $haystack,
                 &$matches,
-                $this->_pregMatchFlags ?: null,
+                $this->_pregMatchFlags ?: 0,
             ]
         );
 

--- a/src/RegExpBuilder.php
+++ b/src/RegExpBuilder.php
@@ -11,7 +11,7 @@ class RegExpBuilder
     protected $_flags = "";
 
     /**
-     * @var string
+     * @var int
      */
     protected $_pregMatchFlags = "";
 
@@ -201,7 +201,7 @@ class RegExpBuilder
     {
         $this->flushState();
 
-        return new RegExp(implode("", $this->_literal), $this->_flags, $this->_pregMatchFlags);
+        return new RegExp(implode("", $this->_literal), $this->_flags, (int)$this->_pregMatchFlags);
     }
 
     private function addFlag($flag)


### PR DESCRIPTION
The flags parameter in preg_match and preg_match all is of type int (not string as previously asserted in the code) and not nullable. Passing null leads to a deprecation warning in newer PHP versions, which is now also checked for in the provided GitHub actions